### PR TITLE
Add additional data from netdb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   YAML_DIR = '/var/lib/systems-dashboard/'.freeze
   YAML_FIELDS = { 'ossec'      => [ 'changed' ],
-                  'netdb'      => [ 'aliases' ],
+                  'netdb'      => [ 'aliases', 'addresses' ],
                   'firewall'   => [ 'rules' ],
                   'advisories' => [ 'details' ],
                 }.freeze

--- a/app/models/cache/servers.rb
+++ b/app/models/cache/servers.rb
@@ -12,6 +12,14 @@ class Cache
 
       import_details = []
       servers.keys.each do |hostname|
+        # For now we're just suppressing anything that belongs to an separate
+        # interface.  In the longer term if we have useful information to report
+        # on them, like firmware updates, model the best way to merge that data
+        # with the owning host.
+        next if hostname =~ /-(ips|sp)[-\.]/
+        next if hostname =~ /-(private|webapp|restrict-prod|unicorn)\./
+        next if hostname =~ /^(coursework|cw).+-(cwdev|webapp|cwprd)\./
+
         serverrec = Server.find_or_create_by(hostname: hostname)
         server_id = serverrec.id
 
@@ -19,17 +27,21 @@ class Cache
           if type == 'alive' || type == 'cobbler' || type == 'puppetdb'
             value = servers[hostname][type]
             import_details << [server_id, 'general', type, value]
-          elsif type == 'netdb'
-            aliases = servers[hostname][type].to_yaml
-            import_details << [server_id, type, 'aliases', aliases]
-          elsif type == 'vmware'
-            servers[hostname][type].keys.each do |vmkey|
-              value = servers[hostname][type][vmkey]
-              import_details << [server_id, type, vmkey, value]
+          elsif type == 'netdb' || type == 'vmware'
+            servers[hostname][type].keys.each do |subtype|
+              value = servers[hostname][type][subtype]
+              if subtype == 'aliases' || subtype == 'addresses'
+                value = value.to_yaml
+              end
+
+              import_details << [server_id, type, subtype, value]
             end
           end
         end
       end
+
+      # Clear existing fields.  General ends up getting a few fields from
+      # the advisories, so we only remove specific fields.
       delete_types = %w(netdb vmware)
       Detail.delete_all(category: delete_types)
       Detail.delete_all(category: 'general', name: %w(alive cobbler puppetdb))

--- a/app/views/server/show.html.erb
+++ b/app/views/server/show.html.erb
@@ -38,10 +38,28 @@
     <td>CPUs</td>
     <td><%= check_child(@server[@host]['vmware'], 'cpus') %></td>
   </tr>
+<% if @server[@host]['netdb'].key?('addresses') && @server[@host]['netdb']['addresses'].count > 0 %>
+  <tr>
+    <td>IPs</td>
+    <td><%= raw(@server[@host]['netdb']['addresses'].join('<br />')) %></td>
+  </tr>
+<% end %>
 <% if @server[@host]['netdb']['aliases'] && @server[@host]['netdb']['aliases'].count > 0 %>
   <tr>
     <td>Host Aliases</td>
-    <td><%= @server[@host]['netdb']['aliases'].join('<br />') %></td>
+    <td><%= raw(@server[@host]['netdb']['aliases'].join('<br />')) %></td>
+  </tr>
+<% end %>
+<% if @server[@host]['netdb'].key?('model') %>
+  <tr>
+    <td>Model (netdb)</td>
+    <td><%= @server[@host]['netdb']['model'] %></td>
+  </tr>
+<% end %>
+<% if @server[@host]['netdb'].key?('os') %>
+  <tr>
+    <td>OS (netdb)</td>
+    <td><%= @server[@host]['netdb']['os'] %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/summary/index.html.erb
+++ b/app/views/summary/index.html.erb
@@ -26,6 +26,7 @@
   <tbody>
     <% @servers.keys.sort.each do |hostname| %>
       <% next if @opt['show_only_flagged'] == 1 && @flags[hostname].empty? %>
+      <% next if @servers[hostname]['vmware'].key?('template') && @servers[hostname]['vmware']['template'] == 't' %>
       <tr>
         <td><%= link_to(shorthost(hostname), server_path(shorthost(hostname))) %></td>
         <td><%= asterisk(@servers[hostname]['netdb']) %></td>

--- a/spec/controllers/advisories_controller_spec.rb
+++ b/spec/controllers/advisories_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AdvisoriesController, type: :controller do
+  fixtures :servers
+  fixtures :details
   describe 'GET #show' do
     context 'displays the main page with all items correctly' do
       before do

--- a/spec/controllers/server_controller_spec.rb
+++ b/spec/controllers/server_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ServerController, type: :controller do
+  fixtures :servers
+  fixtures :details
   require 'yaml'
   describe 'GET #show' do
     context 'displays status for a server' do
@@ -21,6 +23,10 @@ RSpec.describe ServerController, type: :controller do
         expect(response.body).to match(/<td>Status<\/td>\s+<td>On</)
         expect(response.body).to match(/<td>Memory<\/td>\s+<td>4</)
         expect(response.body).to match(/<td>CPUs<\/td>\s+<td>8</)
+        expect(response.body).to match(/<td>Host Aliases<\/td>\s+<td>example2<br \/>example3</)
+        expect(response.body).to match(/<td>IPs<\/td>\s+<td>192.168.1.3<br \/>192.168.1.4</)
+        expect(response.body).to match(/<td>Model \(netdb\)<\/td>\s+<td>Raspberry Pi</)
+        expect(response.body).to match(/<td>OS \(netdb\)<\/td>\s+<td>Linux-Redhat</)
         expect(response.body).to match(/Last puppet run failed/)
         expect(response.body).to match(/Puppet has not run lately, last run at /)
         expect(response.body).to match(/<td>environment<\/td>\s+<td>production</)
@@ -50,6 +56,10 @@ RSpec.describe ServerController, type: :controller do
         expect(response.body).to match(/<td>Status<\/td>\s+<td></)
         expect(response.body).to match(/<td>Memory<\/td>\s+<td>/)
         expect(response.body).to match(/<td>CPUs<\/td>\s+<td>/)
+        expect(response.body).not_to match(/<td>Host Aliases<\/td>/)
+        expect(response.body).to match(/<td>IPs<\/td>\s+<td>192.168.1.5</)
+        expect(response.body).to match(/<td>Model \(netdb\)<\/td>\s+<td>TRS80 Coco2</)
+        expect(response.body).to match(/<td>OS \(netdb\)<\/td>\s+<td>Linux-Centos</)
         expect(response.body).to match(/Last run successful/)
         expect(response.body).to match(/<td>department<\/td>\s+<td>dlss</)
         expect(response.body).to match(/<td>environment<\/td>\s+<td>production</)

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SummaryController, type: :controller do
+  fixtures :servers
+  fixtures :details
   require 'yaml'
   describe 'GET #index' do
     context 'displays a list of all servers' do

--- a/spec/fixtures/details.yml
+++ b/spec/fixtures/details.yml
@@ -8,11 +8,6 @@ example-cobbler:
   category: general
   name: cobbler
   value: 1
-example-netdb:
-  server_id: 1
-  category: netdb
-  name: aliases
-  value: []
 example-puppetdb:
   server_id: 1
   category: general
@@ -48,11 +43,48 @@ test-cobbler:
   category: general
   name: cobbler
   value: 1
-test-netdb:
+
+example-netdb-aliases:
+  server_id: 1
+  category: netdb
+  name: aliases
+  value: ['example2', 'example3']
+example-netdb-addresses:
+  server_id: 1
+  category: netdb
+  name: addresses
+  value: ['192.168.1.3', '192.168.1.4']
+example-netdb-os:
+  server_id: 1
+  category: netdb
+  name: os
+  value: 'Linux-Redhat'
+example-netdb-model:
+  server_id: 1
+  category: netdb
+  name: model
+  value: 'Raspberry Pi'
+test-netdb-aliases:
   server_id: 2
   category: netdb
   name: aliases
   value: []
+test-netdb-addresses:
+  server_id: 2
+  category: netdb
+  name: addresses
+  value: ['192.168.1.5']
+test-netdb-os:
+  server_id: 2
+  category: netdb
+  name: os
+  value: 'Linux-Centos'
+test-netdb-model:
+  server_id: 2
+  category: netdb
+  name: model
+  value: 'TRS80 Coco2'
+
 example-ossec-lastrun:
   server_id: 1
   category: ossec

--- a/spec/views/ossec/index.html.erb_spec.rb
+++ b/spec/views/ossec/index.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'ossec/index.html.erb' do
+  fixtures :servers
+  fixtures :details
   require 'yaml'
 
   # Just make sure it doesn't crash if given no reports, everything else done


### PR DESCRIPTION
Add service model, IPs, and OS from netdb to the servers page.  Also
filter out various hosts coming from netdb that aren't actionable,
such as extra interfaces belonging to a server.

Closes #16
