### PR TITLE
Add ossec data refresh to download

### DIFF
--- a/app/assets/javascripts/upgrades.coffee
+++ b/app/assets/javascripts/upgrades.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/upgrades.scss
+++ b/app/assets/stylesheets/upgrades.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the upgrades controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
                   'netdb'      => [ 'aliases', 'addresses' ],
                   'firewall'   => [ 'rules' ],
                   'advisories' => [ 'details' ],
+                  'upgrades'   => [ 'packages' ],
                 }.freeze
   INT_FIELDS  = { 'ossec'      => [ 'count' ],
                   'general'    => [ 'advisory-count' ],
@@ -45,7 +46,7 @@ class ApplicationController < ActionController::Base
       # hosts that don't have data.
       serverdata[hostname] = {}
       fields = %w(general firewall netdb puppetfacts puppetstatus advisories
-                  vmware ossec)
+                  vmware ossec upgrades)
       fields.each do |root|
         serverdata[hostname][root] = {}
       end

--- a/app/controllers/systems_controller.rb
+++ b/app/controllers/systems_controller.rb
@@ -1,7 +1,7 @@
 class SystemsController < ApplicationController
   def index
-    records = Server.includes(:details)
-      .where(details: {category: %w(general puppetfacts vmware)})
+    categories = %w(general puppetfacts vmware upgrades)
+    records = Server.includes(:details).where(details: { category: categories })
     @servers = convert_yaml(records)
   end
 end

--- a/app/controllers/upgrades_controller.rb
+++ b/app/controllers/upgrades_controller.rb
@@ -1,0 +1,17 @@
+class UpgradesController < ApplicationController
+  def show
+    @host = params[:id]
+    @host << '.stanford.edu' unless /\.stanford\.edu$/ =~ @host
+
+    records = Server.where('hostname' => @host).includes(:details)
+                    .where('details.category' => 'upgrades')
+    all_upgrades = convert_yaml(records)
+    @advisories = if records.count == 0
+                    nil
+                  elsif all_upgrades[@host]['upgrades']['packages'].nil?
+                    nil
+                  else
+                    all_upgrades
+                  end
+  end
+end

--- a/app/helpers/upgrades_helper.rb
+++ b/app/helpers/upgrades_helper.rb
@@ -1,0 +1,2 @@
+module UpgradesHelper
+end

--- a/app/models/cache/upgrades.rb
+++ b/app/models/cache/upgrades.rb
@@ -1,0 +1,66 @@
+class Cache
+  class Upgrades
+    CACHEFILE = '/etc/server-reports/schedule'.freeze
+
+    # Load the schedule of when to upgrade servers, turning into a hash with
+    # hash key the server name and value the scheduled week (0..4).
+    def load_schedule
+      schedule = {}
+      File.open(CACHEFILE, 'r') do |f|
+        f.each_line do |line|
+          m = /^(\d+)\s+(\S+)/.match(line)
+          next if m.nil?
+          week = m[1]
+          server = m[2]
+          schedule[server] = week.to_i
+        end
+      end
+
+      schedule
+    end
+
+    # Create a mapping of weeks to dates, where each week in a year is counted
+    # off 1..4, starting again after 4.
+    def week_to_date_map
+      week_of_year = Time.new.strftime("%V").to_i
+      week_count = week_of_year.modulo(4) + 1
+
+      mapping = {}
+      for i in 0..3 do
+        date = Date.today.beginning_of_week(:monday)
+        date += 1 + ((3-date.wday) % 7)
+        date += i.week
+        mapping[week_count] = date
+        week_count += 1
+        week_count = 1 if week_count > 4
+      end
+
+      mapping[0] = 'On Hold'
+      mapping[99] = 'Not Yet Set'
+      mapping
+    end
+
+    def cache
+      require 'activerecord-import'
+      require 'activerecord-import/base'
+      ActiveRecord::Import.require_adapter('pg')
+
+      week_to_date = week_to_date_map
+      schedule = load_schedule
+
+      import_details = []
+      schedule.keys.each do |hostname|
+        serverrec = Server.find_or_create_by(hostname: hostname)
+        server_id = serverrec.id
+
+        date = week_to_date[schedule[hostname]]
+        import_details << [server_id, 'upgrades', 'date', date]
+      end
+
+      delete_types = %w(upgrades)
+      Detail.delete_all(category: delete_types)
+      columns = %w(server_id category name value)
+      Detail.import(columns, import_details)
+    end
+  end
+end

--- a/app/views/systems/index.html.erb
+++ b/app/views/systems/index.html.erb
@@ -15,6 +15,8 @@
       <td>Project</td>
       <td>CPUs</td>
       <td>Memory</td>
+      <td>Next Upgrade</td>
+      <td>Packages</td>
     </tr>
   </thead>
   <tbody>
@@ -29,6 +31,17 @@
         <td><%= check_child(@servers[hostname]['puppetfacts'], 'project') %></td>
         <td><%= check_child(@servers[hostname]['vmware'], 'memory') %></td>
         <td><%= check_child(@servers[hostname]['vmware'], 'cpus') %></td>
+        <td><%= check_child(@servers[hostname]['upgrades'], 'date') %></td>
+        <td><%= check_child(@servers[hostname]['upgrades'], 'packages')
+          if @servers[hostname]['upgrades'].key?('packages')
+            count = @servers[hostname]['upgrades']['packages'].count
+            if count > 0
+              link_to(count, upgrade_path(shorthost(hostname)))
+            else
+              0
+            end
+          end
+        %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/upgrades/show.html.erb
+++ b/app/views/upgrades/show.html.erb
@@ -1,0 +1,15 @@
+<h1><%= @host %></h1>
+
+  <% if @advisories.nil? %>
+  <p>Could not find any information for this host.</p>
+
+<% elsif @advisories[@host]['upgrades'].key?('packages') && @advisories[@host]['upgrades']['packages'].count > 0 %>
+  <h2>Package Updates for (<%= @advisories[@host]['upgrades']['date'] %>)</h2>
+
+  <% @advisories[@host]['upgrades']['packages'].sort.each do |p| %>
+    <%= p %><br />
+  <% end %>
+
+<% else %>
+  <p>No packages pending update for this machine.</p>
+<% end %>

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -6,5 +6,5 @@ server "#{fetch(:deploy_host)}.stanford.edu", user: fetch(:user),
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
-set :branch, 'database'
+set :branch, 'jonrober'
 set :rails_env, 'development'

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Configures your navigation
 SimpleNavigation::Configuration.run do |navigation|
-  # Define the primary navigation
   navigation.items do |primary|
     primary.item :main, 'Main', root_path
     primary.item :systems, 'Systems Information', systems_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :ossec, only: [:index, :show]
   resources :systems, only: [:index]
   resources :software, only: [:index]
+  resources :upgrades, only: [:show]
 
   get '/summary/index'
   root 'summary#index'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,8 +11,8 @@ every '*/10 * * * *' do
   rake 'download:servers'
 end
 
-# This is also very low resource.
-every '*/10 * * * *' do
+# The ossec update process can take a while, so only every 30m.
+every '*/30 * * * *' do
   rake 'download:ossec'
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,6 +11,11 @@ every '*/10 * * * *' do
   rake 'download:servers'
 end
 
+# Very low resource indeed.
+every '*/10 * * * *' do
+  rake 'download:upgrades'
+end
+
 # The ossec update process can take a while, so only every 30m.
 every '*/30 * * * *' do
   rake 'download:ossec'

--- a/lib/tasks/download/gemnasium.rake
+++ b/lib/tasks/download/gemnasium.rake
@@ -25,6 +25,9 @@ namespace :download do
           end
         rescue Timeout::Error
           success = 0
+        rescue Net::HTTPRetriableError
+          success = 0
+          sleep(10)
         end
         break if success
         count += 1

--- a/lib/tasks/download/ossec.rake
+++ b/lib/tasks/download/ossec.rake
@@ -17,7 +17,7 @@ namespace :download do
     end
 
     # Now get the data and save to file.
-    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + argsd_download.join(' ')
+    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args_download.join(' ')
     output, error, status = Open3.capture3(command)
     if status != 0
       raise "command failed: #{error}"

--- a/lib/tasks/download/ossec.rake
+++ b/lib/tasks/download/ossec.rake
@@ -6,18 +6,10 @@ namespace :download do
     # Default settings.
     cachefile = '/var/lib/systems-dashboard/ossec.yaml'
     server = 'sul-ossec.stanford.edu'
-    args_update = %w{ossec update}
-    args_download = %w{ossec status}
-
-    # Update the cache of data before download.
-    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args_update.join(' ')
-    output, error, status = Open3.capture3(command)
-    if status != 0
-      raise "command failed: #{error}"
-    end
+    args = %w{ossec status}
 
     # Now get the data and save to file.
-    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args_download.join(' ')
+    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args.join(' ')
     output, error, status = Open3.capture3(command)
     if status != 0
       raise "command failed: #{error}"

--- a/lib/tasks/download/ossec.rake
+++ b/lib/tasks/download/ossec.rake
@@ -6,10 +6,18 @@ namespace :download do
     # Default settings.
     cachefile = '/var/lib/systems-dashboard/ossec.yaml'
     server = 'sul-ossec.stanford.edu'
-    args = %w{ossec status}
-    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args.join(' ')
+    args_update = %w{ossec update}
+    args_download = %w{ossec status}
 
-    # Actually run the remctl command and handle output, saving to file.
+    # Update the cache of data before download.
+    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + args_update.join(' ')
+    output, error, status = Open3.capture3(command)
+    if status != 0
+      raise "command failed: #{error}"
+    end
+
+    # Now get the data and save to file.
+    command = '/usr/bin/k5start -qUtf /etc/keytabs/service.sul-reports.keytab -- /usr/bin/remctl ' + server + ' ' + argsd_download.join(' ')
     output, error, status = Open3.capture3(command)
     if status != 0
       raise "command failed: #{error}"

--- a/lib/tasks/download/upgrades.rake
+++ b/lib/tasks/download/upgrades.rake
@@ -1,0 +1,6 @@
+namespace :download do
+  desc 'Update list of pending server upgrades'
+  task upgrades: :environment do
+    Cache::Upgrades.new.cache
+  end
+end

--- a/spec/controllers/upgrades_controller_spec.rb
+++ b/spec/controllers/upgrades_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UpgradesController, type: :controller do
+
+end

--- a/spec/helpers/upgrades_helper_spec.rb
+++ b/spec/helpers/upgrades_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UpgradesHelper. For example:
+#
+# describe UpgradesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UpgradesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
We were only downloading the data from the ossec server, and not also
running the command to regenerate the data on the server.  Fix this and
make the command only run every 30m to make up for the time that takes.
