### PR TITLE
canonical_host now appends .stanford.edu to non-fqdn hosts

### DIFF
--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -24,9 +24,11 @@ class Cache
   # Given a hostname, find if it is an alias to another hostname and return
   # that hostname if so.
   def canonical_host(hostname)
-    load_aliases if @aliases.empty?
+    hostname += '.stanford.edu' unless hostname =~ /\./
 
+    load_aliases if @aliases.empty?
     return @aliases[hostname] if @aliases.key?(hostname)
+
     hostname
   end
 end


### PR DESCRIPTION
ossec is sending data without the fqdn while everything else is sending
with.  Standardize the inputs.